### PR TITLE
Use npm start scripts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ If you're only developing for one platform you can ignore the steps below that a
   
 #### 4) Start your app
 
-- 4.1) Start the react native packager, run `yarn run start` or `npm run start` from the root of your project.
-- 4.2) **[iOS]** Build and run the iOS app, run `react-native run-ios` from the root of your project. The first build will take some time. This will automatically start up a simulator also for you on a successful build if one wasn't already started.
-- 4.3) **[Android]** If you haven't already got an android device attached/emulator running then you'll need to get one running (make sure the emulator is with Google Play / APIs). When ready run `react-native run-android` from the root of your project.
+- 4.1) Start the react native packager, run `yarn run start` or `npm start` from the root of your project.
+- 4.2) **[iOS]** Build and run the iOS app, run `npm run ios` or `yarn run ios` from the root of your project. The first build will take some time. This will automatically start up a simulator also for you on a successful build if one wasn't already started.
+- 4.3) **[Android]** If you haven't already got an android device attached/emulator running then you'll need to get one running (make sure the emulator is with Google Play / APIs). When ready run `npm run android` or `yarn run android` from the root of your project.
 
 If all has gone well you'll see an initial screen like the one below.
   


### PR DESCRIPTION
`react-native run-ios` and `react-native run-android` will fail if you don't have `react-native` installed globally unless you run them with `npm`. Just friendlier for n00bs