### PR TITLE
fix: correctly support API<21 with proper MultiDex support

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -111,7 +111,7 @@ android {
         versionCode 1
         versionName "1.0"
 
-        // Needed until API21, though release builds may shrink sufficiently
+        // Needed to support API<21, though there is a small chance proguard shrinks things sufficiently
         multiDexEnabled true
     }
     splits {
@@ -200,7 +200,7 @@ dependencies {
     *  OPTIONAL SUPPORT LIBS
     * -------------------------------- */
 
-    // Needed until API21, though release builds may shrink sufficiently
+    // Needed to support API<21, though there is a small chance proguard shrinks things sufficiently
     implementation "com.android.support:multidex:1.0.3"
 
     // For Firebase Ads

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -110,6 +110,8 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
+
+        // Needed until API21, though release builds may shrink sufficiently
         multiDexEnabled true
     }
     splits {
@@ -197,6 +199,9 @@ dependencies {
     /* --------------------------------
     *  OPTIONAL SUPPORT LIBS
     * -------------------------------- */
+
+    // Needed until API21, though release builds may shrink sufficiently
+    implementation "com.android.support:multidex:1.0.3"
 
     // For Firebase Ads
     //noinspection GradleCompatible

--- a/android/app/src/main/java/com/invertase/rnfirebasestarter/MainApplication.java
+++ b/android/app/src/main/java/com/invertase/rnfirebasestarter/MainApplication.java
@@ -1,6 +1,6 @@
 package com.invertase.rnfirebasestarter;
 
-import android.app.Application;
+import android.support.multidex.MultiDexApplication;
 
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
@@ -29,7 +29,7 @@ import io.invertase.firebase.storage.RNFirebaseStoragePackage;
 import java.util.Arrays;
 import java.util.List;
 
-public class MainApplication extends Application implements ReactApplication {
+public class MainApplication extends MultiDexApplication implements ReactApplication {
 
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
     @Override

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "5.3.0",
   "private": true,
   "scripts": {
+    "android-bundle": "mkdir -p android/app/src/main/assets && react-native bundle --platform android --dev true --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res/",
     "android": "react-native run-android",
     "ios": "react-native run-ios --simulator=\"iPhone X\"",
     "apk": "cd android && ./gradlew assembleRelease",


### PR DESCRIPTION
Also, old Android APIs can't do network forwards, so dev bundles don't work,
you have to pre-bundle the react-native app and include it even on dev builds.
So I added an android-bundle npm script to run before starting the app on old devices

This is very difficult to test because you must have an actual device with android 4.x on it. The emulators for those APIs don't have the Google APIs at a level sufficient to test anymore (they are too old and you can't upgrade them easily). 

I happen to have an API17 craptablet laying around which is the only reason I noticed this (and was able to fix it and test it)

Fixes #103 