### PR TITLE
fix npm run rename file table overflow error on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,30 +23,31 @@ A basic react native app with [`react-native-firebase`](https://github.com/inver
 - 1.1) `git clone https://github.com/invertase/react-native-firebase-starter.git`
 - 1.2) `cd react-native-firebase-starter` - cd into your newly created project directory.
 - 1.3) Install NPM packages with your package manager of choice - i.e run `yarn` or `npm install`
-- 1.4) **[iOS]** `cd ios` and run `pod install` - if you don't have CocoaPods you can follow [these instructions](https://guides.cocoapods.org/using/getting-started.html#getting-started) to install it.
-- 1.5) **[Android]** No additional steps for android here.
 
 #### 2) Rename Project
 
 **You will need to be running Node version 7.6 or greater for the rename functionality to work**
 
-- 2.0) **[iOS]** `cd ..` to return to the root directory of the project
 - 2.1) `npm run rename` - you'll be prompted to enter a project name and company name
 - 2.2) Note down the package name value - you'll need this when setting up your Firebase project
 
-#### 3) Add `Google Services` files (plist & JSON)
+#### 3) **[iOS]** Install Pods `RN < 0.60.0`
 
-- 3.1) **[iOS]** Follow the `add firebase to your app` instructions [here](https://firebase.google.com/docs/ios/setup#add_firebase_to_your_app) to generate your `GoogleService-Info.plist` file if you haven't done so already - use the package name generated previously as your `iOS bundle ID`.
-- 3.2) **[iOS]** Place this file in the `ios/` directory of your project.
+- 3.1) `cd ios` and run `pod install` - if you don't have CocoaPods you can follow [these instructions](https://guides.cocoapods.org/using/getting-started.html#getting-started) to install it.
+
+#### 4) Add `Google Services` files (plist & JSON)
+
+- 4.1) **[iOS]** Follow the `add firebase to your app` instructions [here](https://firebase.google.com/docs/ios/setup#add_firebase_to_your_app) to generate your `GoogleService-Info.plist` file if you haven't done so already - use the package name generated previously as your `iOS bundle ID`.
+- 4.2) **[iOS]** Place this file in the `ios/` directory of your project.
   - Once added to the directory, add the file to your Xcode project using 'File > Add Files to "[YOUR APP NAME]"…' and selecting the plist file.
-- 3.3) **[Android]** Follow the `manually add firebase` to your app instructions [here](https://firebase.google.com/docs/android/setup#manually_add_firebase) to generate your `google-services.json` file if you haven't done so already - use the package name generated previously as your `Android package name`.
-- 3.4) **[Android]** Place this file in the `android/app/` directory of your project.
+- 4.3) **[Android]** Follow the `manually add firebase` to your app instructions [here](https://firebase.google.com/docs/android/setup#manually_add_firebase) to generate your `google-services.json` file if you haven't done so already - use the package name generated previously as your `Android package name`.
+- 4.4) **[Android]** Place this file in the `android/app/` directory of your project.
   
-#### 4) Start your app
+#### 5) Start your app
 
-- 4.1) Start the react native packager, run `yarn run start` or `npm start` from the root of your project.
-- 4.2) **[iOS]** Build and run the iOS app, run `npm run ios` or `yarn run ios` from the root of your project. The first build will take some time. This will automatically start up a simulator also for you on a successful build if one wasn't already started.
-- 4.3) **[Android]** If you haven't already got an android device attached/emulator running then you'll need to get one running (make sure the emulator is with Google Play / APIs). When ready run `npm run android` or `yarn run android` from the root of your project.
+- 5.1) Start the react native packager, run `yarn run start` or `npm start` from the root of your project.
+- 5.2) **[iOS]** Build and run the iOS app, run `npm run ios` or `yarn run ios` from the root of your project. The first build will take some time. This will automatically start up a simulator also for you on a successful build if one wasn't already started.
+- 5.3) **[Android]** If you haven't already got an android device attached/emulator running then you'll need to get one running (make sure the emulator is with Google Play / APIs). When ready run `npm run android` or `yarn run android` from the root of your project.
 
 If all has gone well you'll see an initial screen like the one below.
   


### PR DESCRIPTION
to prevent this error
```
[replaceInFile] Error occurred:  { [Error: ENFILE: file table overflow, open './ios/Pods/Headers/Private/gRPC-C++/grpcpp/impl/rpc_service_method.h']
  errno: -23,
  code: 'ENFILE',
  syscall: 'open',
  path:
   './ios/Pods/Headers/Private/gRPC-C++/grpcpp/impl/rpc_service_method.h' }
(node:2685) UnhandledPromiseRejectionWarning: Error: ENFILE: file table overflow, open './ios/Pods/Headers/Private/gRPC-C++/grpcpp/impl/rpc_service_method.h'
(node:2685) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:2685) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

same issue address at #86 