### PR TITLE
Update dependencies to match current RNFB release 5.6.0

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -202,15 +202,11 @@ dependencies {
     * ---------------------------- */
 
     // Firebase bom setup
-    implementation platform("com.google.firebase:firebase-bom:22.2.0")
+    implementation platform("com.google.firebase:firebase-bom:24.3.0")
 
-    // Required dependencies
-    //noinspection GradleCompatible
-    implementation "com.google.firebase:firebase-core"
-
-    /* -------------------------
-    *   OPTIONAL FIREBASE SDKS
-    * ------------------------- */
+    /* ----------------
+    *   FIREBASE SDKS
+    * ----------------- */
 
     implementation('com.google.firebase:firebase-ads') {
       // exclude `customtabs` as the support lib version is out of date

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,10 +16,10 @@ buildscript {
         }
     }
     dependencies {
-        classpath('com.android.tools.build:gradle:3.5.0')
-        classpath 'com.google.gms:google-services:4.3.2'
+        classpath('com.android.tools.build:gradle:3.5.3')
+        classpath 'com.google.gms:google-services:4.3.3'
         classpath 'com.google.firebase:perf-plugin:1.3.1'
-        classpath 'io.fabric.tools:gradle:1.31.0'
+        classpath 'io.fabric.tools:gradle:1.31.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -31,19 +31,19 @@ target 'RNFirebaseStarter' do
   pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
 
   # Required by RNFirebase
-  pod 'Firebase/Core', '~> 6.8.1'
+  pod 'Firebase/Core', '~> 6.13.0'
 
   # [OPTIONAL PODS] - comment out pods for firebase products you won't be using.
-  # pod 'Firebase/AdMob', '~> 6.8.1'
-  pod 'Firebase/Auth', '~> 6.8.1'
-  pod 'Firebase/Database', '~> 6.8.1'
-  pod 'Firebase/Functions', '~> 6.8.1'
-  pod 'Firebase/DynamicLinks', '~> 6.8.1'
-  pod 'Firebase/Firestore', '~> 6.8.1'
-  pod 'Firebase/Messaging', '~> 6.8.1'
-  pod 'Firebase/RemoteConfig', '~> 6.8.1'
-  pod 'Firebase/Storage', '~> 6.8.1'
-  pod 'Firebase/Performance', '~> 6.8.1'
+  # pod 'Firebase/AdMob', '~> 6.13.0'
+  pod 'Firebase/Auth', '~> 6.13.0'
+  pod 'Firebase/Database', '~> 6.13.0'
+  pod 'Firebase/Functions', '~> 6.13.0'
+  pod 'Firebase/DynamicLinks', '~> 6.13.0'
+  pod 'Firebase/Firestore', '~> 6.13.0'
+  pod 'Firebase/Messaging', '~> 6.13.0'
+  pod 'Firebase/RemoteConfig', '~> 6.13.0'
+  pod 'Firebase/Storage', '~> 6.13.0'
+  pod 'Firebase/Performance', '~> 6.13.0'
   pod 'Fabric', '~> 1.10.2'
   pod 'Crashlytics', '~> 3.14.0'
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "android-bundle": "ORG_GRADLE_PROJECT_bundleInDev=true npm run android",
     "android": "react-native run-android",
-    "ios": "react-native run-ios --simulator=\"iPhone X\"",
+    "ios": "react-native run-ios --simulator=\"iPhone 11\"",
     "apk": "cd android && ./gradlew assembleRelease",
     "rename": "node ./bin/rename.js",
     "start": "react-native start",
@@ -17,7 +17,7 @@
     "jetifier": "^1.6.4",
     "react": "16.8.6",
     "react-native": "0.60.5",
-    "react-native-firebase": "^5.5.6"
+    "react-native-firebase": "^5.6.0"
   },
   "devDependencies": {
     "@babel/core": "^7.6.0",


### PR DESCRIPTION
Fixes user-noticed issue where starter does not compile out of the box now that Apple Sign-in requires updated Pods

https://github.com/invertase/react-native-firebase/issues/3007